### PR TITLE
Piazzolla ready for Google Fonts

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -12,3 +12,4 @@
 Sol Matas <solmatas@gmail.com>
 Panagiotis Haratzopoulos <p.haratzo@gmail.com>
 Krassen Krestev <cactusoctopus@gmail.com>
+Yanone <post@yanone.de>

--- a/OFL.txt
+++ b/OFL.txt
@@ -18,7 +18,7 @@ with others.
 
 The OFL allows the licensed fonts to be used, studied, modified and
 redistributed freely as long as they are not sold by themselves. The
-fonts, including any derivative works, can be bundled, embedded,
+fonts, including any derivative works, can be bundled, embedded, 
 redistributed and/or sold with any software provided that any reserved
 names are not used by derivative works. The fonts and derivatives,
 however, cannot be released under any other type of license. The

--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ for f in "${files[@]}"; do
     echo "Setup DesignSpace from Glyphs for $f"
     if [ -e temp/building/$f ]; then rm -rf temp/building/$f; fi
     mkdir -p temp/building/$f
-    glyphs2ufo sources/$f.glyphs -m temp/building/$f
+    glyphs2ufo -m temp/building/$f sources/$f.glyphs
     echo "Process DesignSpace for $f"
     python tools/processDesignSpace.py $f
 done
@@ -49,6 +49,7 @@ done
 echo
 echo Fixing fonts
 for VF in fonts/Piazzolla/variable/ttf/*.ttf; do
+    python tools/fixNameTable.py $VF
     gftools fix-dsig -f $VF
     gftools fix-nonhinting $VF "$VF.fix"
     mv "$VF.fix" $VF
@@ -63,6 +64,7 @@ done
 
 if $static; then
     for ttf in fonts/Piazzolla/static/*.ttf; do
+        python tools/fixNameTable.py $ttf
         gftools fix-dsig -f $ttf
         gftools fix-nonhinting $ttf "$ttf.fix"
         mv "$ttf.fix" $ttf
@@ -76,6 +78,7 @@ if $static; then
     done
 
     for otf in fonts/Piazzolla/static/*.otf; do
+        python tools/fixNameTable.py $VF
         gftools fix-dsig -f $otf
         gftools fix-nonhinting $otf "$otf.fix"
         mv "$otf.fix" $otf

--- a/build.sh
+++ b/build.sh
@@ -102,7 +102,7 @@ if $static; then
 fi
 for f in fonts/Piazzolla/variable/ttf/*-VF*; do mv "$f" "${f//-VF/[opsz,wght]}"; done
 cp extra/Thanks.png fonts/Piazzolla
-cp LICENSE.txt fonts/Piazzolla
+cp OFL.txt fonts/Piazzolla
 
 echo
 echo Freezing Small Caps

--- a/sources/Piazzolla-Italic.glyphs
+++ b/sources/Piazzolla-Italic.glyphs
@@ -4127,7 +4127,7 @@ alignmentZones = (
 );
 ascender = 725;
 capHeight = 644;
-custom = Thin;
+custom = "Thin Italic";
 customParameters = (
 {
 name = paramArea;
@@ -4240,7 +4240,7 @@ alignmentZones = (
 );
 ascender = 737;
 capHeight = 660;
-custom = Black;
+custom = "Black Italic";
 customParameters = (
 {
 name = paramArea;

--- a/sources/Piazzolla-Italic.glyphs
+++ b/sources/Piazzolla-Italic.glyphs
@@ -244886,6 +244886,10 @@ value = 1;
 {
 name = weightClass;
 value = 275;
+},
+{
+name = familyName;
+value = "Piazzolla Text";
 }
 );
 interpolationWeight = 45;
@@ -244895,8 +244899,7 @@ instanceInterpolations = {
 "FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.08427;
 };
 isItalic = 1;
-linkStyle = "Text ExtraLight";
-name = "Text ExtraLight Italic";
+name = "ExtraLight Italic";
 weightClass = UltraLight;
 },
 {
@@ -244904,6 +244907,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla Text";
 }
 );
 interpolationWeight = 62;
@@ -244913,8 +244920,7 @@ instanceInterpolations = {
 "FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.17978;
 };
 isItalic = 1;
-linkStyle = "Text Light";
-name = "Text Light Italic";
+name = "Light Italic";
 weightClass = Light;
 },
 {
@@ -244922,6 +244928,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla Text";
 }
 );
 interpolationWeight = 80;
@@ -244931,14 +244941,17 @@ instanceInterpolations = {
 "FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.2809;
 };
 isItalic = 1;
-linkStyle = Text;
-name = "Text Italic";
+name = Italic;
 },
 {
 customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla Text";
 }
 );
 interpolationWeight = 99;
@@ -244948,8 +244961,7 @@ instanceInterpolations = {
 "FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.38764;
 };
 isItalic = 1;
-linkStyle = "Text Medium";
-name = "Text Medium Italic";
+name = "Medium Italic";
 weightClass = Medium;
 },
 {
@@ -244957,6 +244969,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla Text";
 }
 );
 interpolationWeight = 120;
@@ -244966,8 +244982,7 @@ instanceInterpolations = {
 "FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.50562;
 };
 isItalic = 1;
-linkStyle = "Text SemiBold";
-name = "Text SemiBold Italic";
+name = "SemiBold Italic";
 weightClass = SemiBold;
 },
 {
@@ -244975,6 +244990,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla Text";
 }
 );
 interpolationWeight = 149;
@@ -244985,8 +245004,7 @@ instanceInterpolations = {
 };
 isBold = 1;
 isItalic = 1;
-linkStyle = Text;
-name = "Text Bold Italic";
+name = "Bold Italic";
 weightClass = Bold;
 },
 {
@@ -244994,6 +245012,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla Text";
 }
 );
 interpolationWeight = 177;
@@ -245003,8 +245025,7 @@ instanceInterpolations = {
 "FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.82584;
 };
 isItalic = 1;
-linkStyle = "Text ExtraBold";
-name = "Text ExtraBold Italic";
+name = "ExtraBold Italic";
 weightClass = ExtraBold;
 }
 );

--- a/sources/Piazzolla-Italic.glyphs
+++ b/sources/Piazzolla-Italic.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "1340";
+.appVersion = "1342";
 DisplayStrings = (
 "0123456789",
 "0126879354\012/zero.osf/one.osf/two.osf/six.osf/eight.osf/seven.osf/nine.osf/three.osf/five.osf/four.osf \012/zero.tosf/one.tosf/two.tosf/six.tosf/eight.tosf/seven.tosf/nine.tosf/three.tosf/five.tosf/four.tosf \012/zero.tf/one.tf/two.tf/six.tf/eight.tf/seven.tf/nine.tf/three.tf/five.tf/four.tf \012\012Rebuild/space and/space autospace:\012/zero.dnom/one.dnom/two.dnom/three.dnom/four.dnom/five.dnom/six.dnom/seven.dnom/eight.dnom/nine.dnom \012\012sync/space space:\012/zero.lf/figurespace/one.lf/two.lf/three.lf/four.lf/five.lf/six.lf/seven.lf/eight.lf/nine.lf"
@@ -102,7 +102,7 @@ name = "Use Extension Kerning";
 value = 1;
 }
 );
-date = "2018-06-26 18:10:32 +0000";
+date = "2020-07-09 11:41:14 +0000";
 designer = "Juan Pablo del Peral";
 designerURL = "https://www.huertatipografica.com";
 familyName = Piazzolla;
@@ -247671,5 +247671,5 @@ HV = 105;
 };
 };
 versionMajor = 1;
-versionMinor = 200;
+versionMinor = 300;
 }

--- a/sources/Piazzolla.glyphs
+++ b/sources/Piazzolla.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "1340";
+.appVersion = "1342";
 DisplayStrings = (
 "0126879354\012/zero.osf/one.osf/two.osf/six.osf/eight.osf/seven.osf/nine.osf/three.osf/five.osf/four.osf \012/zero.tosf/one.tosf/two.tosf/six.tosf/eight.tosf/seven.tosf/nine.tosf/three.tosf/five.tosf/four.tosf \012/zero.tf/one.tf/two.tf/six.tf/eight.tf/seven.tf/nine.tf/three.tf/five.tf/four.tf/figurespace \012\012Rebuild/space and/space autospace:\012/zero.dnom/one.dnom/two.dnom/three.dnom/four.dnom/five.dnom/six.dnom/seven.dnom/eight.dnom/nine.dnom \012\012sync/space space:\012/zero.lf/figurespace/one.lf/two.lf/three.lf/four.lf/five.lf/six.lf/seven.lf/eight.lf/nine.lf"
 );
@@ -242168,7 +242168,7 @@ instanceInterpolations = {
 "0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.7191;
 "BFC82823-8905-47CE-90FC-B44BF62F9018" = 0.2809;
 };
-name = Text;
+name = "Text Regular";
 },
 {
 customParameters = (

--- a/sources/Piazzolla.glyphs
+++ b/sources/Piazzolla.glyphs
@@ -242128,6 +242128,10 @@ value = 1;
 {
 name = weightClass;
 value = 275;
+},
+{
+name = familyName;
+value = "Piazzolla Text";
 }
 );
 interpolationWeight = 45;
@@ -242136,7 +242140,7 @@ instanceInterpolations = {
 "0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.91573;
 "BFC82823-8905-47CE-90FC-B44BF62F9018" = 0.08427;
 };
-name = "Text ExtraLight";
+name = ExtraLight;
 weightClass = UltraLight;
 },
 {
@@ -242144,6 +242148,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla Text";
 }
 );
 interpolationWeight = 62;
@@ -242152,7 +242160,7 @@ instanceInterpolations = {
 "0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.82022;
 "BFC82823-8905-47CE-90FC-B44BF62F9018" = 0.17978;
 };
-name = "Text Light";
+name = Light;
 weightClass = Light;
 },
 {
@@ -242160,6 +242168,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla Text";
 }
 );
 interpolationWeight = 80;
@@ -242168,13 +242180,17 @@ instanceInterpolations = {
 "0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.7191;
 "BFC82823-8905-47CE-90FC-B44BF62F9018" = 0.2809;
 };
-name = "Text Regular";
+name = Regular;
 },
 {
 customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla Text";
 }
 );
 interpolationWeight = 99;
@@ -242183,7 +242199,7 @@ instanceInterpolations = {
 "0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.61236;
 "BFC82823-8905-47CE-90FC-B44BF62F9018" = 0.38764;
 };
-name = "Text Medium";
+name = Medium;
 weightClass = Medium;
 },
 {
@@ -242191,6 +242207,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla Text";
 }
 );
 interpolationWeight = 120;
@@ -242199,7 +242219,7 @@ instanceInterpolations = {
 "0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.49438;
 "BFC82823-8905-47CE-90FC-B44BF62F9018" = 0.50562;
 };
-name = "Text SemiBold";
+name = SemiBold;
 weightClass = SemiBold;
 },
 {
@@ -242207,6 +242227,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla Text";
 }
 );
 interpolationWeight = 149;
@@ -242216,8 +242240,7 @@ instanceInterpolations = {
 "BFC82823-8905-47CE-90FC-B44BF62F9018" = 0.66854;
 };
 isBold = 1;
-linkStyle = Text;
-name = "Text Bold";
+name = Bold;
 weightClass = Bold;
 },
 {
@@ -242225,6 +242248,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla Text";
 }
 );
 interpolationWeight = 177;
@@ -242233,7 +242260,7 @@ instanceInterpolations = {
 "0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.17416;
 "BFC82823-8905-47CE-90FC-B44BF62F9018" = 0.82584;
 };
-name = "Text ExtraBold";
+name = ExtraBold;
 weightClass = ExtraBold;
 }
 );

--- a/sources/Piazzolla.glyphs
+++ b/sources/Piazzolla.glyphs
@@ -97,7 +97,7 @@ name = "Use Extension Kerning";
 value = 1;
 }
 );
-date = "2018-06-26 18:08:42 +0000";
+date = "2020-07-09 11:41:04 +0000";
 designer = "Juan Pablo del Peral";
 designerURL = "https://www.huertatipografica.com";
 familyName = Piazzolla;
@@ -245143,5 +245143,5 @@ HV = 105;
 };
 };
 versionMajor = 1;
-versionMinor = 200;
+versionMinor = 300;
 }

--- a/tools/fixNameTable.py
+++ b/tools/fixNameTable.py
@@ -1,0 +1,170 @@
+import sys, re, unicodedata, os
+import fontTools.ttLib
+from fontbakery.parse import style_parse
+
+#file = "/Users/yanone/Projekte/Google/Onboarding/piazzolla/fonts/Piazzolla/variable/ttf/Piazzolla-Italic[opsz,wght].ttf"#sys.argv[1]
+file = sys.argv[1]
+ttFont = fontTools.ttLib.TTFont(file)
+
+
+RIBBI_style = [
+    "Regular",
+    "Italic",
+    "Bold",
+    "Bold Italic"
+]
+
+
+fsSelection_values = {
+    "Regular": 64,
+    "Italic": 1,
+    "Bold": 32,
+    "Bold Italic": 33,
+}
+
+macStyle_values = {
+    "Regular": 0,
+    "Italic": 2,
+    "Bold": 1,
+    "Bold Italic": 3,
+}
+
+
+def return_font_file_full_path(folder, filename):
+    font_file_full_path = f"{folder}/{filename}"
+    return font_file_full_path
+
+def return_filename_no_extension(filename):
+    filename_no_extension = os.path.basename(filename).split(".")[0]
+    return filename_no_extension
+
+def return_familyname(filename):
+    name = return_filename_no_extension(filename).split("-")[0]
+    parts = []
+    i = 0
+    for s in name:
+        if unicodedata.category(s) == 'Lu':
+            part = name[:i]
+            if part:
+                parts.append(part)
+            name = name[i:]
+            i = 0
+        i += 1
+    parts.append(name)
+
+    return ' '.join(parts)
+
+def return_stylename(filename):
+    stylename = filename_no_extension.split("-")[1]
+    return stylename
+
+def split_name(string):
+    splitted_name = re.findall('[A-Z][^A-Z]*', string)
+    return splitted_name
+
+def remove_spaces(string):
+    string = "".join(string.split(" "))
+    return string
+
+
+def return_nameID_1(familyname, stylename):
+    if stylename in RIBBI_style:
+        nameID1 = familyname
+    else:
+        if "Italic" in stylename:
+            stylename_without_italic = stylename.replace(" Italic", "")
+            nameID1 = f"{familyname} {stylename_without_italic}"
+        elif "Regular" in stylename:
+            stylename_without_regular = stylename.replace(" Regular", "")
+            nameID1 = f"{familyname} {stylename_without_regular}"
+        else:
+            nameID1 = f"{familyname} {stylename}"
+    return nameID1
+
+def return_nameID_2(stylename):
+    if stylename in RIBBI_style:
+        nameID2 = stylename
+    else:
+        if "Italic" in stylename:
+            nameID2 = "Italic"
+        else:
+            nameID2 = "Regular"
+    return nameID2
+
+def is_RIBBI(stylename):
+    if stylename in RIBBI_style:
+        return True
+    else:
+        return False
+
+
+# Variable Font
+if 'fvar' in ttFont:
+
+    # Sub family name
+    for name in ttFont['name'].names:
+        if name.nameID == 2:
+            name.string = style_parse(ttFont).win_style_name
+
+    # macStyle & fsSelection
+    if '-Italic' in file:
+        ttFont['head'].macStyle |= 1 << 1 # Set  bit 1
+        ttFont['OS/2'].fsSelection |= 1 << 0 # Set bit 0 (Italic)
+        ttFont['OS/2'].fsSelection = ttFont['OS/2'].fsSelection & ~(1<<5) # Unset bit 5 (Bold)
+        ttFont['OS/2'].fsSelection = ttFont['OS/2'].fsSelection & ~(1<<6) # Unset bit 6 (Regular)
+
+# Static FOnt
+else:
+
+    filename_no_extension = return_filename_no_extension(file)
+    familyname = return_familyname(file)
+    temp_stylename = return_stylename(file)
+
+    if temp_stylename != "Italic":
+        stylename = temp_stylename.replace("Italic", " Italic")
+    else:
+        stylename = temp_stylename
+
+    print(familyname, stylename)
+
+    nameID1  = return_nameID_1(familyname, stylename)
+    nameID2  = return_nameID_2(stylename)
+    nameID4  = f"{familyname} {stylename}"
+    nameID6  = f"{remove_spaces(familyname)}-{remove_spaces(stylename)}"
+    nameID16 = familyname
+    nameID17 = stylename
+    nameID18 = nameID4
+
+    # Remove 16, 17, 18
+    try:
+        ttFont["name"].removeNames(nameID=18)
+        ttFont["name"].removeNames(nameID=17)
+        ttFont["name"].removeNames(nameID=16)
+    except:
+        pass
+
+    ttFont["name"].setName( string=nameID1,  nameID=1,  platformID=3, platEncID=1, langID=0x409 )
+    ttFont["name"].setName( string=nameID2,  nameID=2,  platformID=3, platEncID=1, langID=0x409 )
+    ttFont["name"].setName( string=nameID4,  nameID=4,  platformID=3, platEncID=1, langID=0x409 )
+    ttFont["name"].setName( string=nameID6,  nameID=6,  platformID=3, platEncID=1, langID=0x409 )
+    ttFont["name"].setName( string=nameID18,  nameID=18,  platformID=3, platEncID=1, langID=0x409 )
+
+    if not is_RIBBI(stylename):
+        ttFont["name"].setName( string=nameID16, nameID=16, platformID=3, platEncID=1, langID=0x409 )
+        ttFont["name"].setName( string=nameID17, nameID=17, platformID=3, platEncID=1, langID=0x409 )
+
+    # Fix fsSelection and macStyle
+    nameID_2 = ttFont["name"].getName(nameID=2, platformID=3, platEncID=1).toStr()
+    if is_RIBBI(stylename) == True:
+        ttFont["OS/2"].fsSelection = fsSelection_values[nameID_2]
+        ttFont["head"].macStyle = macStyle_values[nameID_2]
+    else:
+        if nameID_2 == "Regular":
+            ttFont["OS/2"].fsSelection = fsSelection_values["Regular"]
+            ttFont["head"].macStyle = macStyle_values["Regular"]
+        else:
+            ttFont["OS/2"].fsSelection = fsSelection_values["Italic"]
+            ttFont["head"].macStyle = macStyle_values["Italic"]
+
+
+ttFont.save(file)


### PR DESCRIPTION
I was commissioned by Google Fonts to prepare Piazzolla for a Google Fonts submission.

The most significant change was to move the "Text" from the style name into the family name, so "Piazzolla-TextRegular" to "PiazzollaText-Regular". A name table script was added that sets the name entries according to GF specs. Otherwise the family is in great shape.

Please accept this PR and then we will proceed with the submission procedure. Thank you.