### PR TITLE
Family names as point sizes

### DIFF
--- a/sources/Piazzolla-Italic.glyphs
+++ b/sources/Piazzolla-Italic.glyphs
@@ -244718,6 +244718,10 @@ value = 1;
 {
 name = weightClass;
 value = 250;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 30;
@@ -244739,6 +244743,10 @@ value = 1;
 {
 name = weightClass;
 value = 275;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 45;
@@ -244757,6 +244765,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 62;
@@ -244775,6 +244787,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 80;
@@ -244792,6 +244808,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 99;
@@ -244810,6 +244830,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 120;
@@ -244828,6 +244852,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 149;
@@ -244847,6 +244875,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 177;
@@ -244865,6 +244897,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 208;
@@ -244885,11 +244921,36 @@ value = 1;
 },
 {
 name = weightClass;
+value = 250;
+},
+{
+name = familyName;
+value = "Piazzolla 14pt";
+}
+);
+interpolationWeight = 30;
+interpolationWidth = 14;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 1;
+};
+isItalic = 1;
+linkStyle = Thin;
+name = "Thin Italic";
+weightClass = Thin;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = weightClass;
 value = 275;
 },
 {
 name = familyName;
-value = "Piazzolla Text";
+value = "Piazzolla 14pt";
 }
 );
 interpolationWeight = 45;
@@ -244899,6 +244960,7 @@ instanceInterpolations = {
 "FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.08427;
 };
 isItalic = 1;
+linkStyle = ExtraLight;
 name = "ExtraLight Italic";
 weightClass = UltraLight;
 },
@@ -244910,7 +244972,7 @@ value = 1;
 },
 {
 name = familyName;
-value = "Piazzolla Text";
+value = "Piazzolla 14pt";
 }
 );
 interpolationWeight = 62;
@@ -244920,6 +244982,7 @@ instanceInterpolations = {
 "FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.17978;
 };
 isItalic = 1;
+linkStyle = Light;
 name = "Light Italic";
 weightClass = Light;
 },
@@ -244931,7 +244994,7 @@ value = 1;
 },
 {
 name = familyName;
-value = "Piazzolla Text";
+value = "Piazzolla 14pt";
 }
 );
 interpolationWeight = 80;
@@ -244941,6 +245004,7 @@ instanceInterpolations = {
 "FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.2809;
 };
 isItalic = 1;
+linkStyle = Regular;
 name = Italic;
 },
 {
@@ -244951,7 +245015,7 @@ value = 1;
 },
 {
 name = familyName;
-value = "Piazzolla Text";
+value = "Piazzolla 14pt";
 }
 );
 interpolationWeight = 99;
@@ -244961,6 +245025,7 @@ instanceInterpolations = {
 "FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.38764;
 };
 isItalic = 1;
+linkStyle = Medium;
 name = "Medium Italic";
 weightClass = Medium;
 },
@@ -244972,7 +245037,7 @@ value = 1;
 },
 {
 name = familyName;
-value = "Piazzolla Text";
+value = "Piazzolla 14pt";
 }
 );
 interpolationWeight = 120;
@@ -244982,6 +245047,7 @@ instanceInterpolations = {
 "FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.50562;
 };
 isItalic = 1;
+linkStyle = SemiBold;
 name = "SemiBold Italic";
 weightClass = SemiBold;
 },
@@ -244993,7 +245059,7 @@ value = 1;
 },
 {
 name = familyName;
-value = "Piazzolla Text";
+value = "Piazzolla 14pt";
 }
 );
 interpolationWeight = 149;
@@ -245004,6 +245070,7 @@ instanceInterpolations = {
 };
 isBold = 1;
 isItalic = 1;
+linkStyle = Regular;
 name = "Bold Italic";
 weightClass = Bold;
 },
@@ -245015,7 +245082,7 @@ value = 1;
 },
 {
 name = familyName;
-value = "Piazzolla Text";
+value = "Piazzolla 14pt";
 }
 );
 interpolationWeight = 177;
@@ -245025,8 +245092,234 @@ instanceInterpolations = {
 "FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.82584;
 };
 isItalic = 1;
+linkStyle = ExtraBold;
 name = "ExtraBold Italic";
 weightClass = ExtraBold;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 14pt";
+}
+);
+interpolationWeight = 208;
+interpolationWidth = 14;
+instanceInterpolations = {
+"FCE02CC8-2979-430D-9DE0-31930C0E296D" = 1;
+};
+isItalic = 1;
+linkStyle = Black;
+name = "Black Italic";
+weightClass = Black;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = weightClass;
+value = 250;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 30;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 1;
+};
+isItalic = 1;
+linkStyle = Thin;
+name = "Thin Italic";
+weightClass = Thin;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = weightClass;
+value = 275;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 45;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.91573;
+"FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.08427;
+};
+isItalic = 1;
+linkStyle = ExtraLight;
+name = "ExtraLight Italic";
+weightClass = UltraLight;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 62;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.82022;
+"FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.17978;
+};
+isItalic = 1;
+linkStyle = Light;
+name = "Light Italic";
+weightClass = Light;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 80;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.7191;
+"FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.2809;
+};
+isItalic = 1;
+linkStyle = Regular;
+name = Italic;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 99;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.61236;
+"FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.38764;
+};
+isItalic = 1;
+linkStyle = Medium;
+name = "Medium Italic";
+weightClass = Medium;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 120;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.49438;
+"FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.50562;
+};
+isItalic = 1;
+linkStyle = SemiBold;
+name = "SemiBold Italic";
+weightClass = SemiBold;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 149;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.33146;
+"FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.66854;
+};
+isBold = 1;
+isItalic = 1;
+linkStyle = Regular;
+name = "Bold Italic";
+weightClass = Bold;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 177;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.17416;
+"FCE02CC8-2979-430D-9DE0-31930C0E296D" = 0.82584;
+};
+isItalic = 1;
+linkStyle = ExtraBold;
+name = "ExtraBold Italic";
+weightClass = ExtraBold;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 208;
+interpolationWidth = 8;
+instanceInterpolations = {
+"FCE02CC8-2979-430D-9DE0-31930C0E296D" = 1;
+};
+isItalic = 1;
+linkStyle = Black;
+name = "Black Italic";
+weightClass = Black;
 }
 );
 kerning = {

--- a/sources/Piazzolla.glyphs
+++ b/sources/Piazzolla.glyphs
@@ -241977,6 +241977,10 @@ value = 1;
 {
 name = weightClass;
 value = 250;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 30;
@@ -241996,6 +242000,10 @@ value = 1;
 {
 name = weightClass;
 value = 275;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 45;
@@ -242012,6 +242020,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 62;
@@ -242028,6 +242040,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 80;
@@ -242043,6 +242059,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 99;
@@ -242059,6 +242079,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 120;
@@ -242075,6 +242099,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 149;
@@ -242093,6 +242121,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 177;
@@ -242109,6 +242141,10 @@ customParameters = (
 {
 name = "Update Features";
 value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 30pt";
 }
 );
 interpolationWeight = 208;
@@ -242122,6 +242158,28 @@ weightClass = Black;
 {
 customParameters = (
 {
+name = familyName;
+value = "Piazzolla 14pt";
+},
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = weightClass;
+value = 250;
+}
+);
+interpolationWeight = 30;
+interpolationWidth = 14;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 1;
+};
+name = Thin;
+},
+{
+customParameters = (
+{
 name = "Update Features";
 value = 1;
 },
@@ -242131,7 +242189,7 @@ value = 275;
 },
 {
 name = familyName;
-value = "Piazzolla Text";
+value = "Piazzolla 14pt";
 }
 );
 interpolationWeight = 45;
@@ -242151,7 +242209,7 @@ value = 1;
 },
 {
 name = familyName;
-value = "Piazzolla Text";
+value = "Piazzolla 14pt";
 }
 );
 interpolationWeight = 62;
@@ -242171,7 +242229,7 @@ value = 1;
 },
 {
 name = familyName;
-value = "Piazzolla Text";
+value = "Piazzolla 14pt";
 }
 );
 interpolationWeight = 80;
@@ -242190,7 +242248,7 @@ value = 1;
 },
 {
 name = familyName;
-value = "Piazzolla Text";
+value = "Piazzolla 14pt";
 }
 );
 interpolationWeight = 99;
@@ -242210,7 +242268,7 @@ value = 1;
 },
 {
 name = familyName;
-value = "Piazzolla Text";
+value = "Piazzolla 14pt";
 }
 );
 interpolationWeight = 120;
@@ -242230,7 +242288,7 @@ value = 1;
 },
 {
 name = familyName;
-value = "Piazzolla Text";
+value = "Piazzolla 14pt";
 }
 );
 interpolationWeight = 149;
@@ -242251,7 +242309,7 @@ value = 1;
 },
 {
 name = familyName;
-value = "Piazzolla Text";
+value = "Piazzolla 14pt";
 }
 );
 interpolationWeight = 177;
@@ -242262,6 +242320,210 @@ instanceInterpolations = {
 };
 name = ExtraBold;
 weightClass = ExtraBold;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 14pt";
+}
+);
+interpolationWeight = 208;
+interpolationWidth = 14;
+instanceInterpolations = {
+"BFC82823-8905-47CE-90FC-B44BF62F9018" = 1;
+};
+name = Black;
+weightClass = Black;
+},
+{
+customParameters = (
+{
+name = familyName;
+value = "Piazzolla 8pt";
+},
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = weightClass;
+value = 250;
+}
+);
+interpolationWeight = 30;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 1;
+};
+name = Thin;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = weightClass;
+value = 275;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 45;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.91573;
+"BFC82823-8905-47CE-90FC-B44BF62F9018" = 0.08427;
+};
+name = ExtraLight;
+weightClass = UltraLight;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 62;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.82022;
+"BFC82823-8905-47CE-90FC-B44BF62F9018" = 0.17978;
+};
+name = Light;
+weightClass = Light;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 80;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.7191;
+"BFC82823-8905-47CE-90FC-B44BF62F9018" = 0.2809;
+};
+name = Regular;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 99;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.61236;
+"BFC82823-8905-47CE-90FC-B44BF62F9018" = 0.38764;
+};
+name = Medium;
+weightClass = Medium;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 120;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.49438;
+"BFC82823-8905-47CE-90FC-B44BF62F9018" = 0.50562;
+};
+name = SemiBold;
+weightClass = SemiBold;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 149;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.33146;
+"BFC82823-8905-47CE-90FC-B44BF62F9018" = 0.66854;
+};
+isBold = 1;
+name = Bold;
+weightClass = Bold;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 177;
+interpolationWidth = 8;
+instanceInterpolations = {
+"0E5388DE-A0E6-4EB4-BC9B-CE5870C9023F" = 0.17416;
+"BFC82823-8905-47CE-90FC-B44BF62F9018" = 0.82584;
+};
+name = ExtraBold;
+weightClass = ExtraBold;
+},
+{
+customParameters = (
+{
+name = "Update Features";
+value = 1;
+},
+{
+name = familyName;
+value = "Piazzolla 8pt";
+}
+);
+interpolationWeight = 208;
+interpolationWidth = 8;
+instanceInterpolations = {
+"BFC82823-8905-47CE-90FC-B44BF62F9018" = 1;
+};
+name = Black;
+weightClass = Black;
 }
 );
 kerning = {

--- a/sources/Piazzolla.stylespace
+++ b/sources/Piazzolla.stylespace
@@ -13,7 +13,7 @@
                 <array>
                     <dict>
                         <key>name</key>
-                        <string>Micro</string>
+                        <string>8pt</string>
                         <key>value</key>
                         <integer>8</integer>
                         <key>range</key>
@@ -24,7 +24,7 @@
                     </dict>
                     <dict>
                         <key>name</key>
-                        <string>Text</string>
+                        <string>14pt</string>
                         <key>value</key>
                         <integer>14</integer>
                         <key>range</key>
@@ -35,17 +35,13 @@
                     </dict>
                     <dict>
                         <key>name</key>
-                        <string>Big</string>
+                        <string>30pt</string>
                         <key>value</key>
                         <integer>30</integer>
                         <key>range</key>
                         <array>
                             <integer>18</integer>
                             <integer>30</integer>
-                        </array>
-                        <key>flags</key>
-                        <array>
-                            <string>ElidableAxisValueName</string>
                         </array>
                     </dict>
                 </array>

--- a/tools/fixNameTable.py
+++ b/tools/fixNameTable.py
@@ -42,8 +42,10 @@ def return_familyname(filename):
     name = return_filename_no_extension(filename).split("-")[0]
     parts = []
     i = 0
+    previous = None
     for s in name:
-        if unicodedata.category(s) == 'Lu':
+        if unicodedata.category(s) in ['Lu', 'Nd'] and not unicodedata.category(s) == previous:
+            previous = unicodedata.category(s)
             part = name[:i]
             if part:
                 parts.append(part)


### PR DESCRIPTION
Changed family names to point sizes (8pt/14pt/30pt) and created all missing static instances.
As a result, the STAT tables of the VFs are now also correct.